### PR TITLE
Passive regen + other fixes

### DIFF
--- a/src/fpsrule/ambient.toml
+++ b/src/fpsrule/ambient.toml
@@ -13,7 +13,7 @@ player_health = { type = "I32", attributes = ["Debuggable", "Networked"] }
 
 hit_freeze = { type = "I32", attributes = ["Debuggable", "Networked"] }
 
-heal_timeout = { type = "I32", attributes = ["Debuggable", "Networked"] }
+heal_timeout = { type = "I32", attributes = ["Debuggable"] }
 
 [messages.shoot.fields]
 ray_origin = { type = "Vec3" }

--- a/src/fpsrule/ambient.toml
+++ b/src/fpsrule/ambient.toml
@@ -13,6 +13,7 @@ player_health = { type = "I32", attributes = ["Debuggable", "Networked"] }
 
 hit_freeze = { type = "I32", attributes = ["Debuggable", "Networked"] }
 
+heal_timeout = { type = "I32", attributes = ["Debuggable", "Networked"] }
 
 [messages.shoot.fields]
 ray_origin = { type = "Vec3" }

--- a/src/fpsrule/server.rs
+++ b/src/fpsrule/server.rs
@@ -2,6 +2,7 @@
 
 use ambient_api::components::core::{player::player, transform::translation};
 use ambient_api::prelude::*;
+
 #[main]
 pub fn main() {
     spawn_query(player()).bind(|results| {
@@ -49,6 +50,11 @@ pub fn main() {
                     );
                     run_async(async move {
                         sleep(114. / 60.).await;
+
+                        if !entity::exists(hit.entity) {
+                            return;
+                        }
+
                         entity::set_component(
                             hit.entity,
                             translation(),

--- a/src/fpsrule/server.rs
+++ b/src/fpsrule/server.rs
@@ -15,19 +15,22 @@ pub fn main() {
             });
         }
     });
+
     messages::Shoot::subscribe(move |_source, msg| {
         let result = physics::raycast_first(msg.ray_origin, msg.ray_dir);
 
         if let Some(hit) = result {
-            if entity::has_component(hit.entity, components::player_health()) {
-                let old_health = entity::get_component(hit.entity, components::player_health());
-                if old_health.is_none() {
-                    return;
-                }
-                let old_health = old_health.unwrap();
+            if hit.entity == msg.source {
+                eprintln!("self hit");
+                return;
+            }
+
+            if let Some(old_health) = entity::get_component(hit.entity, components::player_health())
+            {
                 if old_health <= 0 {
                     return;
                 }
+
                 let new_health = (old_health - 10).max(0);
                 entity::set_component(hit.entity, components::player_health(), new_health);
 


### PR DESCRIPTION
- fpsrule: no self hits
- fpsrule: assert that hit.entity exists after sleep
- fpsrule: passive health regen
- fpsrule: don't sync heal_timeout
